### PR TITLE
Add observe to httpClient options

### DIFF
--- a/projects/ngx-drupal7-services/src/lib/main/main.service.ts
+++ b/projects/ngx-drupal7-services/src/lib/main/main.service.ts
@@ -121,6 +121,7 @@ export class MainService {
       headers: headers,
       withCredentials: true,
       reportProgress: true,
+      observe: 'events'
     };
     return options;
   }


### PR DESCRIPTION
This allows for events to propogate.  Otherwise things like progress reporting on Uploads do not send back in subscribe